### PR TITLE
Fix the broken update check.

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -214,8 +214,7 @@ def get_param_group():
 # ========================
 
 REMOTE_PACKAGE_URL = (
-    "https://raw.githubusercontent.com/Ondsel-Development/"
-    "Ondsel-Lens/master/package.xml"
+    "https://raw.githubusercontent.com/FreeCAD/Ondsel-Lens-Addon/main/package.xml"
 )
 
 


### PR DESCRIPTION
The check was still referring to the Ondsel GitHub repository.

Closes #20.